### PR TITLE
Update to drive motor velocity conversion factor

### DIFF
--- a/frc1388-Swerve-2022/src/main/java/frc/robot/SwerveModule.java
+++ b/frc1388-Swerve-2022/src/main/java/frc/robot/SwerveModule.java
@@ -23,11 +23,14 @@ public class SwerveModule {
     public double m_speed;
 
     private final double secPerMin = 60;
+    private final double metersPerInch = 0.0254;
     private final double motorRotationsPerWheelRotation = 6.67; // from AndyMark
     private final double inchesPerWheelRotation = 4 * Math.PI;
-    private final double metersPerInch = 0.0254;
-    private final double metersPerMotorRotation = (inchesPerWheelRotation * metersPerInch) / motorRotationsPerWheelRotation;
-    private final double metersPerSecondPerRPM = metersPerMotorRotation * secPerMin;
+
+    private final double wheelRPM = (1 / motorRotationsPerWheelRotation);
+    private final double wheelInchesPerMin = wheelRPM * inchesPerWheelRotation;
+    private final double wheelMetersPerMin = wheelInchesPerMin * metersPerInch;
+    private final double metersPerSecondPerRPM = wheelMetersPerMin / secPerMin;
 
     private final WPI_TalonSRX m_rotationMotor;
     private final AnalogInput m_rotationEncoder;


### PR DESCRIPTION
This update to the drive motor encoder's getVelocity conversion factor
accomplishes two thing:

- Correct a bug in the units
- Separate out each step of the conversion process, for clarity